### PR TITLE
Fix for RuntimeError: Expected object of scalar type Byte but got scalar type Bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Complete but Unofficial PyTorch Implementation of [Complex-YOLO: Real-time 3D Ob
     
 #### Test [without downloading dataset] 
 
-    1. $ python test_detection.py --split=smaples --folder=sampledata  
-    2. $ python test_both_side_detection.py --split=smaples --folder=sampledata
+    1. $ python test_detection.py --split=sample --folder=sampledata  
+    2. $ python test_both_side_detection.py --split=sample --folder=sampledata
 
 #### Demo Video [[Click to Play](https://www.youtube.com/watch?v=JzywsbuXFOg)]
 [![complex-yolov3_gif][complex-yolov3_gif]](https://youtu.be/JzywsbuXFOg)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -295,7 +295,8 @@ def non_max_suppression_rotated_bbox(prediction, conf_thres=0.95, nms_thres=0.4)
         while detections.size(0):
             #large_overlap = rotated_bbox_iou(detections[0, :6].unsqueeze(0), detections[:, :6], 1.0, False) > nms_thres # not working
             large_overlap = rotated_bbox_iou_polygon(detections[0, :6], detections[:, :6]) > nms_thres
-            large_overlap = torch.from_numpy(large_overlap.astype('uint8'))
+            # large_overlap = torch.from_numpy(large_overlap.astype('uint8'))
+            large_overlap = torch.from_numpy(large_overlap)
             label_match = detections[0, -1] == detections[:, -1]
             # Indices of boxes with lower confidence scores, large IOUs and matching labels
             invalid = large_overlap & label_match


### PR DESCRIPTION
**Error:**
Traceback (most recent call last):
  File "test_detection.py", line 124, in <module>
    detections = utils.non_max_suppression_rotated_bbox(detections, opt.conf_thres, opt.nms_thres) 
  File "/aimldl-cod/external/Complex-YOLOv3/utils/utils.py", line 301, in non_max_suppression_rotated_bbox
    invalid = large_overlap & label_match
RuntimeError: Expected object of scalar type Byte but got scalar type Bool for argument #2 'other' in call to _th_and

**Changes**
removed uint8 as large_overlap datatype
**Remarks**
Fixed the error

